### PR TITLE
Remove reference to PyPDF2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DGGen
 
-DGGen is a program written in Python to generate characters for the pen-and-paper roleplaying game Delta Green from Arc Dream Publishing.  It follows the character creations rules included in Delta Green:Need to Know and the Delta Green Agent's Handbook.  The Python libraries PyPDF2 and ReportLab are required.  Characters are created one-per-page into a PDF.  The second-page of the character sheet is included as the final page in the PDF.  By default, between 5 and 40 characters of alternating genders are created in each of the following professions:
+DGGen is a program written in Python to generate characters for the pen-and-paper roleplaying game Delta Green from Arc Dream Publishing.  It follows the character creations rules included in Delta Green:Need to Know and the Delta Green Agent's Handbook.  The [ReportLab](https://www.reportlab.com/dev/opensource/) library is required.  Characters are created one-per-page into a PDF.  The second-page of the character sheet is included as the final page in the PDF.  By default, between 5 and 40 characters of alternating genders are created in each of the following professions:
 
 * Anthropologist
 * Business Executive


### PR DESCRIPTION
Remove reference to PyPDF2, since we aren't using it any longer.