### PR TITLE
Bump Reportlab requirement to latest.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-reportlab==3.6.2
+reportlab~=4.0


### PR DESCRIPTION
Older versions of Reportlab don't install under newer Python versions.